### PR TITLE
fix(options): src match 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 import { spawnSync } from "child_process";
 import { lstatSync, existsSync } from "fs";
-import { sep } from "path";
+import { resolve, sep } from "path";
 
 interface AssemblyScriptPluginOptions {
   srcMatch: string;
@@ -70,7 +70,7 @@ export default function assemblyScriptPlugin(
     name: "vite-plugin-assemblyscript-asc",
     handleHotUpdate({ file }) {
       if (
-        file.indexOf(`${options.projectRoot}${sep}${options.srcMatch}`) > -1
+        file.startsWith(resolve(options.projectRoot, options.srcMatch))
       ) {
         spawnAscCmd(baseScriptCmd, "debug");
       }


### PR DESCRIPTION
Given input:
```ts
{
    projectRoot: "./",
    srcEntryFile: "src/index.ts",
    srcMatch: "src/",
}
```
Expected: `ctx.file` from `handleHotUpdate` should be matched by "./src/" (both get expanded)
Actual: the dot "." is not recognised properly as a qualified matching path

**About cross-platform compatibility**: this works fine, for "node:path" resolves path well.